### PR TITLE
Include missing <vector> header for the tests

### DIFF
--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -7,6 +7,7 @@
 #include <string_view>
 #include <type_traits>
 #include <numeric>
+#include <vector>
 
 #include "lex.h"
 


### PR DESCRIPTION
This makes the test compile (and run) for me.